### PR TITLE
Add SCM for org.glassfish:jakarta.el

### DIFF
--- a/recipes/org/glassfish/_artifact/jakarta.el/scm.yaml
+++ b/recipes/org/glassfish/_artifact/jakarta.el/scm.yaml
@@ -1,0 +1,8 @@
+---
+type: "git"
+uri: "https://github.com/jakartaee/expression-language.git"
+tagMapping:
+  - pattern: 3.0.3
+    tag: 3.0.3-RELEASE-COMBO
+  - pattern: 3.0.4
+    tag: 3.0.4-impl


### PR DESCRIPTION
This is just a copy of `recipes/jakarta/el/scm.yaml` to `recipes/org/glassfish/_artifact/jakarta.el/scm.yaml` since the artifacts produced by this build live under two different group identifiers.
