### PR TITLE
Fix URL and add tagMapping for jboss-jaxrs-api_2.1_spec

### DIFF
--- a/scm-info/org/jboss/spec/javax/ws/rs/_artifact/jboss-jaxrs-api_2.1_spec/scm.yaml
+++ b/scm-info/org/jboss/spec/javax/ws/rs/_artifact/jboss-jaxrs-api_2.1_spec/scm.yaml
@@ -1,3 +1,6 @@
 ---
 type: "git"
-uri: "https://github.com/jboss/jboss-jaxrs-api_spec.git"
+uri: "https://github.com/jboss/jboss-jakarta-jaxrs-api_spec.git"
+tagMapping:
+  - pattern: .*
+    tag: jboss-jaxrs-api_2.1_spec-$0


### PR DESCRIPTION
Existing URL was for 1.x versions, but versions 2.x and 3.x have moved to https://github.com/jboss/jboss-jakarta-jaxrs-api_spec.git.