### PR TITLE
Fix icu4j

### DIFF
--- a/scm-info/com/ibm/icu/scm.yaml
+++ b/scm-info/com/ibm/icu/scm.yaml
@@ -1,6 +1,7 @@
 ---
 type: "git"
 uri: "https://github.com/unicode-org/icu.git"
+path: "icu4j"
 tagMapping:
   - pattern: (\d+)\.(\d+)
     tag: release-$1-$2

--- a/scm-info/org/unicode/icu/scm.yaml
+++ b/scm-info/org/unicode/icu/scm.yaml
@@ -1,4 +1,0 @@
----
-type: "git"
-uri: "https://github.com/unicode-org/icu.git"
-path: "tools/release/java"


### PR DESCRIPTION
The `org/unicode/icu` artifact doesn't exist, so I deleted it. It should be `com/ibm/icu`.

The path `tools/release/java` does exist with a `pom.xml`, but it can't build from this file. The build type is actually ant+ivy build in `icu4j`.
