### PR TITLE
Remove Android and publishTo sections from build.sbt

### DIFF
--- a/build-info/github.com/luben/zstd-jni/build.yaml
+++ b/build-info/github.com/luben/zstd-jni/build.yaml
@@ -1,3 +1,4 @@
 ---
 preBuildScript: |
+    sed -i -e '/\/\/ Sonatype/,/\}/d' -e '/\/\/ Android \.aar/,/\/\/ classified Jars$/d' build.sbt
     sed -i -e 's/com\.github\.joprice/io.github.joprice/;' -e 's/0\.2\.1/0.2.2/;' project/plugins.sbt


### PR DESCRIPTION
This removes the Android artifact from the build, since we don't have an Android SDK installed, and we don't have a `gradle` on the `PATH`.

This removes the Sonatype `publishTo` section since having it there interferes with the one in `global.sbt`.