### PR TITLE
Add JDK for dropwizard 2.2.0

### DIFF
--- a/build-info/github.com/dropwizard/metrics/_version/2.2.0/build.yaml
+++ b/build-info/github.com/dropwizard/metrics/_version/2.2.0/build.yaml
@@ -1,0 +1,2 @@
+---
+javaVersion: "7"


### PR DESCRIPTION
@stuartwdouglas I thought initially from https://github.com/redhat-appstudio/jvm-build-service/blob/e45fdb3f4634c592ba8c8ca554773345d9103600/java-components/build-request-processor/src/main/java/com/redhat/hacbs/container/analyser/build/LookupBuildInfoCommand.java#L171-L173 that it would try JDK7 first but it seems to try 8-17 ?