### PR TITLE
Modify how baseVersionSuffix is defined

### DIFF
--- a/build-info/github.com/scala/scala/build.yaml
+++ b/build-info/github.com/scala/scala/build.yaml
@@ -1,6 +1,6 @@
 ---
 alternativeArgs:
-  - "'set Global / baseVersionSuffix:=\"\"'"
+  - "'set baseVersionSuffix in Global :=\"\"'"
   - "enableOptimizer"
   - "dist/mkPack"
   - "publish"


### PR DESCRIPTION
This avoids errors like
```
<set>:1: error: value / is not a member of object sbt.Global
Global / baseVersionSuffix:=""
```