### PR TITLE
Add scm mapping for duct-tape.

### DIFF
--- a/scm-info/org/rnorth/duct-tape/scm.yaml
+++ b/scm-info/org/rnorth/duct-tape/scm.yaml
@@ -1,0 +1,3 @@
+---
+type: "git"
+uri: "https://github.com/rnorth/duct-tape.git"


### PR DESCRIPTION
Adds an scm mapping for the duct-tape library (which is used by testcontainers amongst others).
Without this it fails with
```
[WARN ] - Failed to determine the SCM for org.rnorth.duct-tape:duct-tape:jar:1.0.8: Failed to obtain a list of tags from https://github.com/rnorth/${project.artifactId}
```

As when resolving the SCM url `project.artifactId` is, presumably, not treated as a replaceable property. 