### PR TITLE
Add com.diffplug.gradle.spotless to disabled plugins

### DIFF
--- a/disabled-plugins/gradle.yaml
+++ b/disabled-plugins/gradle.yaml
@@ -1,4 +1,5 @@
 disabledPlugins:
+  - "com.diffplug.gradle.spotless"
   - "kotlin.gradle.targets.js"
   - "org.gradle.api.plugins.quality"
   - "org.gradle.plugins.signing"


### PR DESCRIPTION
I am seeing build errors with `com.diffplug.gradle.spotless.SpotlessTask` in part due to our files (e.g., `.hacbs-init/`) in the build directory.

Ideally, we should not have any extra files in the build directory as these can end up being deployed in certain archives, particularly tar or zip files.