### PR TITLE
Add enforceVersion for hibernate-orm

### DIFF
--- a/build-info/github.com/hibernate/hibernate-orm/build.yaml
+++ b/build-info/github.com/hibernate/hibernate-orm/build.yaml
@@ -1,0 +1,2 @@
+---
+enforceVersion: true

--- a/build-info/github.com/hibernate/hibernate-orm/build.yaml
+++ b/build-info/github.com/hibernate/hibernate-orm/build.yaml
@@ -1,2 +1,3 @@
 ---
 enforceVersion: true
+javaVersion: 11


### PR DESCRIPTION
While we _shouldn't_ need the javaVersion I was getting `2024-05-09 12:13:03,204 ERROR [com.red.hac.con.ver.VerifyBuiltArtifactsCommand] (main) Class org.hibernate.orm.tooling.gradle.Helper version in file hibernate-gradle-plugin-6.1.4.Final.jar changed from 55.0 (Java 11) to 61.0 (Java 17). Rerun build with -source 11 -target 11` without it. This is because its problem in the 6.x (and earlier) series - see  https://github.com/hibernate/hibernate-orm/commit/12127b2272250bef0d24d5ba22654d829efaced1 