### PR TITLE
Add scm-info and build-info for com.github.fge:json-patch

### DIFF
--- a/build-info/github.com/java-json-tools/json-patch/build.yaml
+++ b/build-info/github.com/java-json-tools/json-patch/build.yaml
@@ -7,4 +7,5 @@ additionalArgs:
 preBuildScript: |
   sed -i /options.addStringOption/d build.gradle
   sed -i /.*propdeps.*/d build.gradle
-  sed -i -e 's/provided/compileOnly/' project.gradle
+  [[ -f project.gradle ]] && sed -i -e 's/provided/compileOnly/' project.gradle
+  [[ -f build.gradle ]] && sed -i -e 's/provided/compileOnly/' build.gradle

--- a/build-info/github.com/java-json-tools/json-patch/build.yaml
+++ b/build-info/github.com/java-json-tools/json-patch/build.yaml
@@ -5,7 +5,8 @@ additionalArgs:
   - "-x"
   - "checkSigningRequirements"
 preBuildScript: |
-  sed -i /options.addStringOption/d build.gradle
-  sed -i /.*propdeps.*/d build.gradle
+  sed -i '/options.addStringOption/d' build.gradle
+  sed -i '/.*group: "org.springframework.build.gradle".*/d' build.gradle
+  sed -i '/.*propdeps.*/d' build.gradle
   [[ -f project.gradle ]] && sed -i -e 's/provided/compileOnly/' project.gradle
   [[ -f build.gradle ]] && sed -i -e 's/provided/compileOnly/' build.gradle

--- a/scm-info/com/github/fge/_artifact/json-patch/scm.yaml
+++ b/scm-info/com/github/fge/_artifact/json-patch/scm.yaml
@@ -1,0 +1,3 @@
+---
+type: "git"
+uri: "https://github.com/java-json-tools/json-patch.git"


### PR DESCRIPTION
Essentially the propdeps plugin no longer exists in public repositories. But we can use Gradle `compileOnly` instead of `provided` to work around it.