### PR TITLE
Remove enforceVersion

### DIFF
--- a/build-info/github.com/pgjdbc/pgjdbc/build.yaml
+++ b/build-info/github.com/pgjdbc/pgjdbc/build.yaml
@@ -1,2 +1,0 @@
----
-enforceVersion: true


### PR DESCRIPTION
PGJDBC doesn't need `enforceVersion` but special handling for its stage-vote-release-plugin - see https://github.com/redhat-appstudio/jvm-build-service/pull/1714 